### PR TITLE
Update mdbread.pyx

### DIFF
--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -63,7 +63,8 @@ transformers = {
     "Boolean": lambda x: bool(int(x)),
     "Text": lambda x: x.decode(ENCODING),
     "DateTime": lambda dt: time.strptime(dt, "%m/%d/%y %H:%M:%S"),
-    "Memo/Hyperlink": str
+    "Memo/Hyperlink": str,
+    "Currency": as_double
 }
 
 cdef class MDB(object):

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -168,8 +168,5 @@ cdef class Table(object):
         g_free(self.bound_lens)
  
     def to_data_frame(self):
-        rows = []
-        for row in self:
-            rows.append(row)
         names = self._column_names()
-        return pandas.DataFrame(rows, columns=names)
+        return pandas.DataFrame([row for row in self], columns=names)

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -83,8 +83,7 @@ cdef class MDB(object):
 
         tables = []
         for i in range(self._handle.num_catalog):
-            entry = <MdbCatalogEntry*> \
-                    g_ptr_array_index(self._handle.catalog, i)
+            entry = <MdbCatalogEntry*> g_ptr_array_index(self._handle.catalog, i)
             name = entry.object_name
             if entry.object_type == MDB_TABLE:
                 if not b"MSys" in name:
@@ -114,10 +113,8 @@ cdef class Table(object):
         self.tbl = mdb_read_table_by_name(mdb._handle,
                                           self.name,MDB_TABLE)
         self.ncol = self.tbl.num_cols
-        self.bound_values = \
-            <char**> g_malloc(<int>(self.ncol * sizeof(char*)))
-        self.bound_lens = \
-            <int*> g_malloc(<int> (self.ncol * sizeof(int)))
+        self.bound_values = <char**> g_malloc(<int>(self.ncol * sizeof(char*)))
+        self.bound_lens = <int*> g_malloc(<int> (self.ncol * sizeof(int)))
 
         for j in range(self.ncol):
             self.bound_values[j] = <char*> g_malloc0(MDB_BIND_SIZE)
@@ -160,8 +157,7 @@ cdef class Table(object):
 
         _transformers = [transformers[t] for t in col_types]
         while mdb_fetch_row(self.tbl):
-            row = [_transformers[j](self.bound_values[j]) 
-                   for j in range(self.ncol)]
+            row = [_transformers[j](self.bound_values[j]) for j in range(self.ncol)]
             yield row
 
     def __del__(self):
@@ -177,4 +173,3 @@ cdef class Table(object):
             rows.append(row)
         names = self._column_names()
         return pandas.DataFrame(rows, columns=names)
-

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -81,7 +81,7 @@ cdef class MDB(object):
         cdef MdbCatalogEntry* entry
 
         tables = []
-        for i in xrange(self._handle.num_catalog):
+        for i in range(self._handle.num_catalog):
             entry = <MdbCatalogEntry*> \
                     g_ptr_array_index(self._handle.catalog, i)
             name = entry.object_name
@@ -118,7 +118,7 @@ cdef class Table(object):
         self.bound_lens = \
             <int*> g_malloc(<int> (self.ncol * sizeof(int)))
 
-        for j in xrange(self.ncol):
+        for j in range(self.ncol):
             self.bound_values[j] = <char*> g_malloc0(MDB_BIND_SIZE)
 
         mdb_read_columns(self.tbl)
@@ -126,7 +126,7 @@ cdef class Table(object):
     def _column_names(self):
         names = []
         cdef MdbColumn* col
-        for j in xrange(self.ncol):
+        for j in range(self.ncol):
             col = <MdbColumn*> g_ptr_array_index(self.tbl.columns, j)
             names.append(col.name.decode(ENCODING))
         return names
@@ -148,7 +148,7 @@ cdef class Table(object):
         cdef char* col_type
         col_types = []
 
-        for j in xrange(self.ncol):
+        for j in range(self.ncol):
             col = <MdbColumn*> g_ptr_array_index(self.tbl.columns, j)
             col_type = mdb_get_colbacktype_string(col)
             col_types.append(col_type.decode(ENCODING))
@@ -160,11 +160,11 @@ cdef class Table(object):
         _transformers = [transformers[t] for t in col_types]
         while mdb_fetch_row(self.tbl):
             row = [_transformers[j](self.bound_values[j]) 
-                   for j in xrange(self.ncol)]
+                   for j in range(self.ncol)]
             yield row
 
     def __del__(self):
-        for i in xrange(self.ncol):
+        for i in range(self.ncol):
             g_free(self.bound_values[i])
 
         g_free(self.bound_values)

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -1,6 +1,7 @@
 import pandas
 import numpy
-import time
+
+from datetime import datetime
 from collections import namedtuple
 
 ENCODING = "iso-8859-1"
@@ -55,6 +56,11 @@ def as_double(x):
     except:
         return numpy.nan
 
+def as_date(date):
+    date_string = date.decode(ENCODING) if type(date) == bytes else date
+
+    return datetime.strptime(date_string, "%m/%d/%y %H:%M:%S")
+
 transformers = {
     "Integer": lambda x: int(x) if x != "" else "",
     "Long Integer": int,
@@ -62,7 +68,7 @@ transformers = {
     "Double": as_double,
     "Boolean": lambda x: bool(int(x)),
     "Text": lambda x: x.decode(ENCODING),
-    "DateTime": lambda dt: time.strptime(dt, "%m/%d/%y %H:%M:%S"),
+    "DateTime": as_date,
     "Memo/Hyperlink": str,
     "Currency": as_double
 }


### PR DESCRIPTION
Changes:
1. Use `range` instead of `xrange` since Python 2 will reach end of life.
2. Add `Currency` data type to transformer.
3. Simplify table iteration using list comprehension in `Tables.to_data_frame` method.
4. Fix `datetime` data type parsing error for database generated from Ms Access 2019.
5. Remove some unnecessary line terminating and whitespace